### PR TITLE
Don't force -auto-all

### DIFF
--- a/mwc-random-monad.cabal
+++ b/mwc-random-monad.cabal
@@ -29,7 +29,6 @@ Library
   if impl(GHC > 7.2.2)
     Ghc-options:     -fsimpl-tick-factor=500
   Ghc-options:       -O2 -Wall
-  Ghc-prof-options:  -auto-all
 
 source-repository head
   type:     mercurial


### PR DESCRIPTION
Cabal now allows you to set profiling detail in a more fine-grained way using
--profiling-detail.

Forcing -auto-all significantly decreases the signal-to-noise when profiling a
larger project using mwc-random.